### PR TITLE
only open /dev/*random once, do unbuffered reads

### DIFF
--- a/lib/Rand/Urandom.pm
+++ b/lib/Rand/Urandom.pm
@@ -71,6 +71,7 @@ sub try_syscall {
 	return $buf;
 }
 
+my $fh;
 sub rand_bytes {
 	my $num = shift;
 
@@ -80,13 +81,13 @@ sub rand_bytes {
 	if (!$buf) {
 		local $! = undef;
 		my $file = -r '/dev/arandom' ? '/dev/arandom' : '/dev/urandom';
-		open(my $fh, '<:raw', $file) || die "Rand::Urandom: Can't open $file: $!";
-
-		my $got = read($fh, $buf, $num);
+		if (! $fh) {
+			open($fh, '<:raw', $file) || die "Rand::Urandom: Can't open $file: $!";
+		}
+		my $got = sysread($fh, $buf, $num);
 		if ($got == 0 || $got != $num) {
 			die "Rand::Urandom: failed to read from $file: $!";
 		}
-		close($fh) || die "Rand::Urandom: close failed: $!";
 	}
 	return $buf;
 }


### PR DESCRIPTION
Constantly opening and closing /dev/*random kills performance. If you only open it once and do unbuffered reads, it's still fork-safe, but about 50x faster.